### PR TITLE
David/w-tinylfu

### DIFF
--- a/ObsidianWrapper/ObsidianWrapper.jsx
+++ b/ObsidianWrapper/ObsidianWrapper.jsx
@@ -9,6 +9,9 @@ function ObsidianWrapper(props) {
   const { algo, capacity } = props
   const [cache, setCache] = React.useState(new LFUCache(Number(capacity || 2000)));
   if(algo === 'LRU') setCache(new LRUCache(Number(capacity || 2000)));  // You have to put your Google Chrome Obsidian developer tool extension id to connect Obsidian Wrapper with dev tool
+  if(algo === 'W-TinyLFU') {
+    // TODO add logic to create w-tiny lfu caches using setCache
+  } 
   const chromeExtensionId = 'apcpdmmbhhephobnmnllbklplpaoiemo';
   // initialice cache in local storage
   //window.localStorage.setItem('cache', JSON.stringify(cache));

--- a/ObsidianWrapper/ObsidianWrapper.jsx
+++ b/ObsidianWrapper/ObsidianWrapper.jsx
@@ -1,6 +1,7 @@
 import * as React from "https://esm.sh/react@18";
 import LFUCache from '../src/Browser/lfuBrowserCache.js';
 import LRUCache from '../src/Browser/lruBrowserCache.js';
+import { WLRUCache, SLRUCache } from "../src/Browser/wTinyLFUBrowserCache";
 import { insertTypenames } from '../src/Browser/insertTypenames.js';
 
 const cacheContext = React.createContext();

--- a/src/Browser/FrequencySketch.js
+++ b/src/Browser/FrequencySketch.js
@@ -1,0 +1,15 @@
+const FrequencySketch = () => {
+
+  const RESET_MASK = 0x7777777777777777;
+  const ONE_MASK = 0x1111111111111111;
+
+  let sampleSize, blockMask, size;
+  const table = [];
+
+  const updateCapacity = maxSize => {
+    
+  }  
+
+}
+
+FrequencySketch();

--- a/src/Browser/FrequencySketch.js
+++ b/src/Browser/FrequencySketch.js
@@ -1,3 +1,23 @@
+// CONVERT TO TYPESCRIPT FOR TYPE ENFORCING (MOSTLY TO INTEGERS)
+
+const nearestPowerOfTwo = num => {
+  const exp = Math.floor(Math.log2(num));
+  if (Math.pow(2, exp) === num) return num;
+
+  return Math.pow(2, exp+1);
+}
+
+const hashCode = (input) => {
+  let hash, code;
+  hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    code = input.charCodeAt(i);
+    hash = ((hash<<5)-hash)+code;
+    hash = hash & hash;
+  }
+  return hash;
+}
+
 const FrequencySketch = () => {
 
   const RESET_MASK = 0x7777777777777777;
@@ -6,10 +26,129 @@ const FrequencySketch = () => {
   let sampleSize, blockMask, size;
   const table = [];
 
+  /**
+   * Initializes and increases the capacity of this FrequencySketch instance
+   * so it can accurately estimate the popularity of data given the maximum
+   * size of the cache. Frequency counts become zero when resizing.
+   * 
+   * @param maxSize cache capacity
+   */
   const updateCapacity = maxSize => {
-    
-  }  
+    const max = Math.floor(maxSize);  //to ensure it's an integer
+    if(table.length >= max) return;
 
+    table = new Array(Math.max(nearestPowerOfTwo(max), 8));
+    sampleSize = (maxSize === 0) ? 10 : (10*max);
+    blockMask = (table.length >>> 3) - 1;
+
+    if (sampleSize <= 0) sampleSize = Number.MAX_SAFE_INTEGER;
+    size = 0;
+  }  
+  /**
+   * Returns true if the sketch has not been initialized, indicating updateCapcity
+   * needs to be called before tracking frequencies. 
+   */
+  const isNotInitialized = () => {
+    return table.length === 0;
+  }
+  /**
+   * Returns the estimated frequency of an element, up to the maximum(15).
+   * 
+   * @param el the element being counted
+   * @return the estimated frequency - required to be nonnegative
+   */
+
+  const frequency = el => {
+    if(isNotInitialized()) return 0;
+    
+    const count = new Array(4);
+
+    const blockHash = supphash(hashCode(el));
+    const counterHash = rehash(blockHash);
+    const block = (blockHash & blockMask) << 3;
+
+    for (let i = 0; i < 4; i++) {
+      const h = counterHash >>> (i << 3);
+      const index = (h >>> 1) & 15;
+      const offset = h & 1;
+      count[i] = ((table[block+offset+(i<<1)] >>> (index << 2)) & 15);
+    }
+    return Math.min(...count);
+  }
+
+  /**
+   * Increment the frequency of the element if it does not exceed the maximum(15)
+   * @param el element to add
+   */
+  const increment = el => {
+    if (isNotInitialized()) return;
+
+    const index = new Array[8];
+
+    const blockHash = supphash(hashCode(el));
+    const counterHash = rehash(blockHash);
+    const block = (blockHash & blockMask) << 3;
+
+    for (const i = 0; i < 4; i++) {
+      const h = counterHash >>> (i << 3);
+      index[i] = (h >>> 1) & 15;
+      const offset = h & 1;
+      index[i + 4] = block + offset + (i << 1);
+    }
+    const incremented =
+          incrementAt(index[4], index[0])
+        | incrementAt(index[5], index[1])
+        | incrementAt(index[6], index[2])
+        | incrementAt(index[7], index[3]);
+
+    if (incremented && (++size == sampleSize)) {
+      reset();
+    }
+  }
+
+  /** Applies a supplemental hash functions for less collisions. */
+  const supphash = x => {
+    x ^= x >> 17;
+    x *= 0xed5ad4bb;
+    x ^= x >> 11;
+    x *= 0xac4c1b51;
+    x ^= x >> 15;
+    return x;
+}
+
+  /** Applies another round of hashing to acheive three round hashing. */
+  const rehash = x => {
+    x *= 0x31848bab;
+    x ^= x >> 14;
+    return x;
+  }
+
+  /**
+   * Increments the specified counter by 1 if it is not already at the maximum value (15).
+   *
+   * @param i the table index (16 counters)
+   * @param j the counter to increment
+   * @return if incremented
+   */
+  const incrementAt = (i,j) => {
+    const offset = j << 2;
+    const mask = (15 << offset);
+    if ((table[i] & mask) != mask) {
+      table[i] += (1 << offset);
+      return true;
+    }
+    return false;
+  }
+
+  /** Reduces every counter by half of its original value. */
+  const reset = () => {
+    let count = 0;
+    for (let i = 0; i < table.length; i++) {
+      count += bitCount(table[i] & ONE_MASK);
+      table[i] = (table[i] >>> 1) & RESET_MASK;
+    }
+    size = (size - (count >>> 2)) >>> 1;
+  }
 }
 
 FrequencySketch();

--- a/src/Browser/lruBrowserCache.js
+++ b/src/Browser/lruBrowserCache.js
@@ -91,7 +91,9 @@ LRUCache.prototype.put = function (key, value) {
   if (this.nodeHash.get(key).size > this.capacity){
     const tempHead = this.head.next;
     this.removeNode(tempHead);
-    this.nodeHash.delete(tempTail.key);
+    this.nodeHash.delete(tempHead.key);
+    // return tempHead for use in SLRU
+    return tempHead;
   }
 }
 

--- a/src/Browser/lruBrowserCache.js
+++ b/src/Browser/lruBrowserCache.js
@@ -31,6 +31,7 @@ LRUCache.prototype.removeNode = function (node) {
   next.prev = prev;
 };
 
+
 LRUCache.prototype.addNode = function (node) {
   const tempTail = this.tail.prev;
   tempTail.next = node;
@@ -39,6 +40,30 @@ LRUCache.prototype.addNode = function (node) {
   node.next = this.tail;
   node.prev = tempTail;
 }
+
+// Like get, but doesn't update anything
+LRUCache.prototype.peek = function(key) {
+  const node = this.nodeHash.get(key);
+  if (!node) return null;
+  return node.value;
+}
+
+// Like removeNode, but takes key
+LRUCache.prototype.delete = function (key) {
+  const node = this.nodeHash.get(key);
+  const prev = node.prev;
+  const next = node.next; 
+  prev.next = next; 
+  next.prev = prev;
+}
+
+// updates a node or adds a node
+// LRUCache.prototype.set = function (key, node) {
+//   const foundNode = this.nodeHash.get(key);
+//   if (foundNode) this.removeNode(foundNode);
+//   this.addNode(node);
+//   return node.value;
+// }
 
 LRUCache.prototype.get = function(key) {
   const node = this.nodeHash.get(key);

--- a/src/Browser/wTinyLFUBrowserCache.js
+++ b/src/Browser/wTinyLFUBrowserCache.js
@@ -2,7 +2,9 @@ import { plural } from "https://deno.land/x/deno_plural/mod.ts";
 
 import normalizeResult from "./normalize.js";
 import destructureQueries from "./destructure.js";
+import LRUCache from './lruBrowserCache.js';
 
+// Basic list node structure
 class Node {
   constructor (key, value) {
     this.key = key;
@@ -10,3 +12,104 @@ class Node {
     this.next = this.prev = null;
   }
 }
+/*****
+* Window LRU
+*****/
+export function WLRUCache(capacity) {
+  this.capacity = capacity;
+  this.currentSize = 0;
+  this.ROOT_QUERY = {};
+  this.ROOT_MUTATION = {};
+  this.nodeHash = new Map();
+
+  this.head = new Node('head', null);
+  this.tail = new Node('tail', null);
+  this.head.next = this.tail;
+  this.tail.prev = this.head;
+}
+// Methods copied from lru browser cache
+WLRUCache.prototype = Object.create(LRUCache.prototype, {constructor: {value: WLRUCache}});
+
+/*****
+* Main SLRU Cache
+*****/
+export function SLRUCache(capacity) {
+  // TODO: Figure out initial capacities for each segment
+  // Probationary LRU Cache using existing LRU structure in lruBrowserCache.js
+  this.probationaryLRU = new LRUCache;
+  // Protected LRU Cache
+  this.protectedLRU = new LRUCache;
+}
+
+// Get item from cache, 
+// updates last access and promotes items to protected
+SLRUCache.prototype.get = function (key) {
+  // get the item from the protectedLRU
+  const protectedItem = this.protectedLRU.get(key);
+  // check to see if the item is in the probationaryLRU
+  const probationaryItem = this.probationaryLRU.peek(key);
+
+  // If the item is in neither segment, return undefined
+  if (protectedItem === undefined && probationaryItem === undefined) return;
+
+  // If the item only exists in the protected segment, return that item
+  if (protectedItem !== undefined) return protectedItem;
+
+  // If the item only exists in the probationary segment, promote to protected and return item
+  this.probationaryLRU.delete(key);
+  this.protectedLRU.put(key, probationaryItem);
+  return probationaryItem;
+}
+
+// Get item from cache, update last access,
+// and promotes existing items to protected
+SLRUCache.prototype.get = function (key) {
+  const protectedItem = this.protectedLRU.get(key);
+  const probationaryItem = this.probationaryLRU.peek(key);
+
+  // if the key is found in neither segment, return undefined
+  if (protectedItem === undefined && probationaryItem === undefined) return;
+
+  // if found in protected, return the item
+  if (protectedItem !== undefined) return protectedItem;
+
+  // if found in probationary, promote and return item
+  this.probationaryLRU.delete(key);
+  this.protectedLRU.put(key, probationaryItem);
+  return probationaryItem
+}
+
+// Get an item from a key without updating access or promoting
+SLRUCache.prototype.peek = function (key) {
+  const protectedItem = this.protectedLRU.peek(key);
+  const probationaryItem = this.probationaryLRU.peek(key);
+
+  // return the protectedItem unless it is undefined, then return probationaryItem instead
+  return protectedItem === undefined ? probationaryItem : protectedItem;
+}
+
+// add or update item in cache
+// if item does not exist, added to probational segment
+// if item exists in probational segment, update value and promote to protected
+// if exists in protected segment, update and make most recent
+SLRUCache.prototype.put = function (key, node) {
+  // if the item is in the protected segment, update it
+  if (this.protectedLRU.nodeHash.get(key)) this.protectedLRU.put(key, node);
+  // if the item is in the probationary segment, 
+  // promote and update it
+  else if (this.probationaryLRU.nodeHash(key)) {
+    this.probationaryLRU.delete(key);
+    this.protectedLRU.put(key, node);
+  }
+  // if in neither, add item to the probationary segment
+  else this.probationaryLRU.put(key, node)
+}
+
+// deletes an item from BOTH segments of the cache
+SLRUCache.prototype.delete = function (key) {
+  this.protectedLRU.delete(key);
+  this.probationaryLRU.delete(key);
+}
+
+// TODO - add logic to ensure that items deleted from protected cache enter the probationary cache
+// perhaps through .options? Needs research

--- a/src/Browser/wTinyLFUBrowserCache.js
+++ b/src/Browser/wTinyLFUBrowserCache.js
@@ -1,0 +1,12 @@
+import { plural } from "https://deno.land/x/deno_plural/mod.ts";
+
+import normalizeResult from "./normalize.js";
+import destructureQueries from "./destructure.js";
+
+class Node {
+  constructor (key, value) {
+    this.key = key;
+    this.value = value;
+    this.next = this.prev = null;
+  }
+}


### PR DESCRIPTION
# Checklist

- [X] Bugfix
- [X] New feature
- [ ] Refactor

# Related Issue

No existing W-TinyLFU policy
Small issue in LRU's put method that wasn't evicting entries from hash properly if over capacity.

# Solution

Created W-TinyLFU with SLRU and WLRU sub-caches. Imported, adjusted, and created methods for these sub-caches caches to appropriately allow for all required caching operations. Created a Frequency Sketch to allow the TinyLFU to probabilistically predict best fit for SLRU admission. 
Switch a variable in the LRU eviction policy on its put method

# Additional Info

W-TinyLFU still requires its own unique methods, TinyLFU admission policy logic, and integration of the Frequency Sketch and Hill Climber
