### PR TITLE
added logic to respond to request for algo/capacity from content.js

### DIFF
--- a/ObsidianWrapper/ObsidianWrapper.jsx
+++ b/ObsidianWrapper/ObsidianWrapper.jsx
@@ -26,6 +26,16 @@ function ObsidianWrapper(props) {
   // if(!algo) setCache(new LFUCache(Number(capacity || 2000)))
   // if(algo === 'LRU') setCache(new LRUCache(Number(capacity || 2000)));  // You have to put your Google Chrome Obsidian developer tool extension id to connect Obsidian Wrapper with dev tool
   // if(algo === 'W-TinyLFU') setCache(new WTinyLFUCache(Number(capacity || 2000))); 
+
+  window.addEventListener('message', msg => {
+    if(msg.data.type === 'algocap'){
+      window.postMessage({
+        algo: algo ? algo : 'LFU',
+        capacity: capacity ? capacity : 2000
+      })
+    }
+  });
+
   const chromeExtensionId = 'apcpdmmbhhephobnmnllbklplpaoiemo';
   // initialice cache in local storage
   //window.localStorage.setItem('cache', JSON.stringify(cache));


### PR DESCRIPTION
# Checklist

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

# Related Issue

- Obsidian 8.0 Devtools was unable to get the current Algorithm and Capacity that is in use until a query was made from within the application wrapped by Obsidian.

# Solution

- Added logic to obsidian wrapper to respond to a request for the Algorithm and Capacity from devtools' content.js and respond with the Algorithm and Capacity currently being utilized. 

# Additional Info

- N/A
