### PR TITLE
David/w tinylfu

### DIFF
--- a/src/Browser/FrequencySketch.js
+++ b/src/Browser/FrequencySketch.js
@@ -17,7 +17,7 @@ export function FrequencySketch() {
     const max = Math.floor(maxSize);  //to ensure it's an integer
     if(table.length >= max) return;
 
-    table = Array(Math.max(nearestPowerOfTwo(max), 8)).fill().map(()=>Array(2));
+    table = Array(Math.max(nearestPowerOfTwo(max), 8)).fill().map(()=>Array(2).fill(0));
     sampleSize = (maxSize === 0) ? 10 : (10*max);
     blockMask = (table.length >>> 3) - 1;
 
@@ -40,7 +40,6 @@ export function FrequencySketch() {
 
   this.frequency = function(el) {
     if(isNotInitialized()) return 0;
-    
     const count = Array(4);
 
     const blockHash = supphash(hashCode(el));
@@ -64,11 +63,11 @@ export function FrequencySketch() {
   this.increment = function(el) {
     if (isNotInitialized()) return;
 
-    const index = Array[8];
-
+    const index = Array(8);
     const blockHash = supphash(hashCode(el));
     const counterHash = rehash(blockHash);
     const block = (blockHash & blockMask) << 3;
+    //in case we get that [Object object] bs
 
     for (let i = 0; i < 4; i++) {
       const h = counterHash >>> (i << 3);
@@ -81,10 +80,10 @@ export function FrequencySketch() {
         | incrementAt(index[5], index[1])
         | incrementAt(index[6], index[2])
         | incrementAt(index[7], index[3]);
-
     if (incremented && (++size == sampleSize)) {
       reset();
     }
+
   }
   
   /**

--- a/src/Browser/hillclimb.js
+++ b/src/Browser/hillclimb.js
@@ -1,0 +1,91 @@
+HillClimb = function(neighborsFunc, valueFunc, start, steepest) {
+	this.neighborsFunc = neighborsFunc;
+	this.valueFunc = valueFunc;
+	this.setNode(start);
+	this.steps = 0;
+	this.steepest = !!steepest;
+
+    /** Avoid mistakes by always setting the value to match the node. */
+  this.setNode = function(node) {
+    this.node = node;
+    this.value = this.valueFunc(node);
+  };
+
+  /** Run one or more steps toward the solution. */
+  this.step = function(stepCount) {
+    if (!stepCount || stepCount < 0) stepCount = 1<<30;
+    const neighborsFunc = this.neighborsFunc, valueFunc = this.valueFunc, steepest = this.steepest;
+    const node = this.node, value = this.value, i = 0;
+    for (i = 0; i < stepCount; ++i) {
+      const nbs = neighborsFunc(node), nbsl = nbs.length;
+      const nextVal = value;
+      const nextNode = node;
+      for (const j = 0; j < nbsl; ++j) {
+        const nb = nbs[j];
+        const nbVal = valueFunc(nb);
+        if (nbVal > nextVal) {
+          nextNode = nb;
+          nextVal = nbVal;
+          if (!steepest && j > 0) break;
+        }
+      }
+      if (nextVal <= valueFunc(node)) break;
+      node = nextNode;
+      value = nextVal;
+    }
+    this.steps += i + 1;
+    this.setNode(node);
+    
+    return node;
+  };
+
+  this.run = function(stepMs, stepCb, doneCb) {
+    const lastNode = this.node, lastValue = this.value;
+    const stepInt = null;
+    const hillclimb = this;
+    stepInt = setInterval(function() {
+      hillclimb.step(1);
+      if (stepCb) stepCb(hillclimb.node, hillclimb.value, hillclimb.steps);
+      if (hillclimb.value == lastValue) {
+        clearInterval(stepInt);
+        if (doneCb) doneCb(hillclimb.node, hillclimb.value, hillclimb.steps);
+        return;
+      }
+      lastNode = hillclimb.node; lastValue = hillclimb.value;
+    }, stepMs);
+  };
+
+  this.runWithRestart = function(stepMs, stepCb, doneCb, localDoneCb, nodeFunc) {
+    const bestNode = this.node, bestValue = this.value;
+    const hillclimb = this;
+    
+    const complete = function() {
+      hillclimb.setNode(bestNode);
+      doneCb(hillclimb.node, hillclimb.value, hillclimb.steps);
+    };
+    
+    const maxFails = 4, fails = 0;
+    const attempt = function() {
+      hillclimb.setNode(nodeFunc());
+      
+      hillclimb.run.call(hillclimb, stepMs, stepCb, function() {
+        localDoneCb.apply(hillclimb, arguments);
+        if (hillclimb.value > bestValue) {
+          bestNode = hillclimb.node;
+          bestValue = hillclimb.value;
+          fails = 0;
+        } else {
+          ++fails;
+        }
+        if (fails == maxFails) {
+          complete();
+        } else {
+          setTimeout(attempt, 0);
+        }
+      });
+    };
+    attempt();
+  };
+};
+
+

--- a/src/Browser/hillclimb.js
+++ b/src/Browser/hillclimb.js
@@ -1,3 +1,175 @@
+///hillclimber.java
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A hill climbing algorithm to tune the admission window size.
+ *
+ * @author ben.manes@gmail.com (Ben Manes)
+ */
+public interface HillClimber {
+
+  /**
+   * Records that a hit occurred with a full cache.
+   *
+   * @param key the key accessed
+   * @param queue the queue the entry was found in
+   * @param isFull if the cache is fully populated
+   */
+  void onHit(long key, QueueType queue, boolean isFull);
+
+  /**
+   * Records that a miss occurred with a full cache.
+   *
+   * @param key the key accessed
+   * @param isFull if the cache is fully populated and had to evict
+   */
+  void onMiss(long key, boolean isFull);
+
+  /**
+   * Determines how to adapt the segment sizes.
+   *
+   * @param windowSize the current window size
+   * @param probationSize the current probation size
+   * @param protectedSize the current protected size
+   * @param isFull if the cache is fully populated
+   * @return the adjustment to the segments
+   */
+  Adaptation adapt(double windowSize, double probationSize, double protectedSize, boolean isFull);
+
+  enum QueueType {
+    WINDOW, PROBATION, PROTECTED
+  }
+
+  /** The adaptation type and its magnitude. */
+  final class Adaptation {
+    public enum Type {
+      HOLD, INCREASE_WINDOW, DECREASE_WINDOW
+    }
+
+    private static final Adaptation HOLD = new Adaptation(0, Type.HOLD);
+
+    public final double amount;
+    public final Type type;
+
+    private Adaptation(double amount, Type type) {
+      checkArgument(amount >= 0, "Step size %s must be positive", amount);
+      this.type = checkNotNull(type);
+      this.amount = amount;
+    }
+
+    /** Returns the adaption based on the amount, where a negative value decreases the window. */
+    public static Adaptation adaptBy(double amount) {
+      if (amount == 0) {
+        return hold();
+      } else if (amount < 0) {
+        return decreaseWindow(Math.abs(amount));
+      } else {
+        return increaseWindow(amount);
+      }
+    }
+    public static int roundToInt(double amount) {
+      return (amount < 0) ? (int) Math.floor(amount) : (int) Math.ceil(amount);
+    }
+
+    public static Adaptation hold() {
+      return HOLD;
+    }
+    public static Adaptation increaseWindow(double amount) {
+      return new Adaptation(amount, Type.INCREASE_WINDOW);
+    }
+    public static Adaptation decreaseWindow(double amount) {
+      return new Adaptation(amount, Type.DECREASE_WINDOW);
+    }
+
+    @Override
+    public String toString() {
+      switch (type) {
+        case HOLD: return "0";
+        case INCREASE_WINDOW: return "+" + amount;
+        case DECREASE_WINDOW: return "-" + amount;
+        default: throw new IllegalStateException();
+      }
+    }
+  }
+}
+
+
+///abstractclimber.java
+public abstract class AbstractClimber implements HillClimber {
+  private static final boolean debug = false;
+
+  protected int sampleSize;
+  protected int hitsInMain;
+  protected int hitsInWindow;
+  protected int hitsInSample;
+  protected int missesInSample;
+  protected double previousHitRate;
+
+  @Override
+  public void onMiss(long key, boolean isFull) {
+    if (isFull) {
+      missesInSample++;
+    }
+  }
+
+  @Override
+  public void onHit(long key, QueueType queueType, boolean isFull) {
+    if (isFull) {
+      hitsInSample++;
+
+      if (queueType == QueueType.WINDOW) {
+        hitsInWindow++;
+      } else {
+        hitsInMain++;
+      }
+    }
+  }
+
+  @Override
+  public Adaptation adapt(double windowSize, double probationSize,
+      double protectedSize, boolean isFull) {
+    if (!isFull) {
+      return Adaptation.hold();
+    }
+
+    checkState(sampleSize > 0, "Sample size may not be zero");
+    int sampleCount = (hitsInSample + missesInSample);
+    if (sampleCount < sampleSize) {
+      return Adaptation.hold();
+    }
+
+    double hitRate = (double) hitsInSample / sampleCount;
+    Adaptation adaption = Adaptation.adaptBy(adjust(hitRate));
+    resetSample(hitRate);
+
+    if (debug) {
+      System.out.printf("%.2f\t%.2f%n", 100 * hitRate, windowSize);
+    }
+    return adaption;
+  }
+
+  /** Returns the amount to adapt by. */
+  protected abstract double adjust(double hitRate);
+
+  /** Starts the next sample period. */
+  protected void resetSample(double hitRate) {
+    previousHitRate = hitRate;
+    missesInSample = 0;
+    hitsInSample = 0;
+    hitsInWindow = 0;
+    hitsInMain = 0;
+  }
+}
+
+
+
+
+
+
+
+
+
 HillClimb = function(neighborsFunc, valueFunc, start, steepest) {
 	this.neighborsFunc = neighborsFunc;
 	this.valueFunc = valueFunc;

--- a/src/Browser/wTinyLFU Sub-Caches/lruSub-cache.js
+++ b/src/Browser/wTinyLFU Sub-Caches/lruSub-cache.js
@@ -101,7 +101,7 @@ LRUCache.prototype.put = function (key, value) {
 
   // check capacity - if over capacity, remove and reassign head node
   // if (Object.nodeHash[this.nodeHash].length > capacity) 
-  if (this.nodeHash.get(key).size > this.capacity){
+  if (this.nodeHash.size > this.capacity){
     const tempHead = this.head.next;
     this.removeNode(tempHead);
     this.nodeHash.delete(tempHead.key);

--- a/src/Browser/wTinyLFU Sub-Caches/lruSub-cache.js
+++ b/src/Browser/wTinyLFU Sub-Caches/lruSub-cache.js
@@ -2,7 +2,6 @@ import { plural } from "https://deno.land/x/deno_plural@2.0.0/mod.ts";
 
 import normalizeResult from "../normalize.js";
 import destructureQueries from "../destructure.js";
-import { FrequencySketch } from "../FrequencySketch.js";
 
 class Node {
   constructor (key, value) {
@@ -33,14 +32,13 @@ LRUCache.prototype.removeNode = function (node) {
 };
 
 
-LRUCache.prototype.addNode = async function (node) {
+LRUCache.prototype.addNode = function (node) {
   const tempTail = this.tail.prev;
   tempTail.next = node;
   
   this.tail.prev = node;
   node.next = this.tail;
   node.prev = tempTail;
-  await this.sketch.increment(JSON.stringify(node.value));
 }
 
 // Like get, but doesn't update anything
@@ -50,13 +48,14 @@ LRUCache.prototype.peek = function(key) {
   return node.value;
 }
 
-// Like removeNode, but takes key
+// Like removeNode, but takes key and deletes from hash
 LRUCache.prototype.delete = function (key) {
   const node = this.nodeHash.get(key);
   const prev = node.prev;
   const next = node.next; 
   prev.next = next; 
   next.prev = prev;
+  this.nodeHash.delete(key);
 }
 
 // updates a node or adds a node
@@ -83,7 +82,7 @@ LRUCache.prototype.getCandidate = function () {
   const tempHead = this.head.next;
   this.removeNode(tempHead);
   this.nodeHash.delete(tempHead.key);
-  return tempHead;
+  return {key: tempHead.key, value: tempHead.value};
 }
 
 LRUCache.prototype.put = function (key, value) {
@@ -106,7 +105,7 @@ LRUCache.prototype.put = function (key, value) {
     this.removeNode(tempHead);
     this.nodeHash.delete(tempHead.key);
     // return tempHead for use in w-TinyLFU's SLRU cache
-    return tempHead;
+    return {key: tempHead.key, value: tempHead.value};
   }
 }
 

--- a/src/Browser/wTinyLFU Sub-Caches/slruSub-cache.js
+++ b/src/Browser/wTinyLFU Sub-Caches/slruSub-cache.js
@@ -10,14 +10,12 @@ import LRUCache from './lruSub-cache.js';
 export default function SLRUCache(capacity) {
   // Probationary LRU Cache using existing LRU structure in lruBrowserCache.js
   this.probationaryLRU = new LRUCache(capacity * .20);
-  this.probationaryLRU.sketch = this.sketch;
   // Protected LRU Cache
   this.protectedLRU = new LRUCache(capacity * .80);
-  this.protectedLRU.sketch = this.sketch;
 }
 
-// Get item from cache, 
-// updates last access and promotes items to protected
+// Get item from cache, updates last access, 
+// and promotes existing items to protected
 SLRUCache.prototype.get = function (key) {
   // get the item from the protectedLRU
   const protectedItem = this.protectedLRU.get(key);
@@ -25,35 +23,16 @@ SLRUCache.prototype.get = function (key) {
   const probationaryItem = this.probationaryLRU.peek(key);
 
   // If the item is in neither segment, return undefined
-  if (protectedItem === undefined && probationaryItem === undefined) return;
+  if (protectedItem === null && probationaryItem === null) return;
 
   // If the item only exists in the protected segment, return that item
-  if (protectedItem !== undefined) return protectedItem;
+  if (protectedItem !== null) return protectedItem.value;
 
   // If the item only exists in the probationary segment, promote to protected and return item
-  this.probationaryLRU.delete(key);
   // if adding an item to the protectedLRU results in ejection, demote ejected node
   this.putAndDemote(key, probationaryItem);
+  this.probationaryLRU.delete(key);
   return probationaryItem;
-}
-
-// Get item from cache, update last access,
-// and promotes existing items to protected
-SLRUCache.prototype.get = function (key) {
-  const protectedItem = this.protectedLRU.get(key);
-  const probationaryItem = this.probationaryLRU.peek(key);
-
-  // if the key is found in neither segment, return undefined
-  if (protectedItem === undefined && probationaryItem === undefined) return;
-
-  // if found in protected, return the item
-  if (protectedItem !== undefined) return protectedItem;
-
-  // if found in probationary, promote and return item
-  this.probationaryLRU.delete(key);
-  // if adding an item to the protectedLRU results in ejection, demote ejected node
-  this.putAndDemote(key, probationaryItem);
-  return probationaryItem
 }
 
 // Get an item from a key without updating access or promoting
@@ -62,7 +41,7 @@ SLRUCache.prototype.peek = function (key) {
   const probationaryItem = this.probationaryLRU.peek(key);
 
   // return the protectedItem unless it is undefined, then return probationaryItem instead
-  return protectedItem === undefined ? probationaryItem : protectedItem;
+  return protectedItem === null ? probationaryItem : protectedItem;
 }
 
 // add or update item in cache
@@ -75,8 +54,8 @@ SLRUCache.prototype.put = function (key, node) {
   else if (this.probationaryLRU.nodeHash(key)) {
     // if the item is in the probationary segment, 
     // promote and update it
-    this.probationaryLRU.delete(key);
     this.putAndDemote(key, node);
+    this.probationaryLRU.delete(key);
   }
   // if in neither, add item to the probationary segment
   else this.probationaryLRU.put(key, node)
@@ -95,8 +74,8 @@ SLRUCache.prototype.has = function (key) {
 
 // Adds a node to the protectedLRU 
 // if that results in an ejection, add the ejected node to the probationary LRU
-SLRUCache.prototype.putAndDemote = function (key, node) {
+SLRUCache.prototype.putAndDemote = function (key, value) {
   // if adding an item to the protectedLRU results in ejection, demote ejected node
-  const demoted = this.protectedLRU.put(key, node);
+  const demoted = this.protectedLRU.put(key, value);
   if (demoted) this.probationaryLRU.put(demoted.key, demoted);
 }

--- a/src/Browser/wTinyLFUBrowserCache.js
+++ b/src/Browser/wTinyLFUBrowserCache.js
@@ -174,7 +174,7 @@ WTinyLFUCache.prototype.write = async function (queryStr, respObj, deleteFlag) {
         else if (wasFoundIn === 'WLRU') await this.WLRU.put(hash, newObj);
       } else {
         const typeName = hash.slice(0, hash.indexOf('~'));
-        await this.WLRU.put(hash, resFromNormalize[hash]);
+        await this.putAndPromote(hash, resFromNormalize[hash]);
         for(const key in this.ROOT_QUERY) {
           if(key.includes(typeName + 's') || key.includes(plural(typeName))) {
             this.ROOT_QUERY[key].push(hash);

--- a/src/Browser/wTinyLFUBrowserCache.js
+++ b/src/Browser/wTinyLFUBrowserCache.js
@@ -23,29 +23,31 @@ export default function WTinyLFUCache (capacity) {
   this.currentSize = 0;
   this.ROOT_QUERY = {};
   this.ROOT_MUTATION = {};
-  this.sketch = new FrequencySketch;
+  this.sketch = new FrequencySketch();
+  this.sketch.updateCapacity(capacity);
 
   this.WLRU = new LRUCache(capacity * .01);
   this.WLRU.sketch = this.sketch;
   this.SLRU = new SLRUCache(capacity * .99);
-  this.SLRU.sketch = this.sketch;
+  this.SLRU.probationaryLRU.sketch = this.sketch;
+  this.SLRU.protectedLRU.sketch = this.sketch;
 }
 
-WTinyLFUCache.prototype.putAndPromote = function (key, node) {
-  const WLRUCandidate = this.WLRU.put(key, node);
+WTinyLFUCache.prototype.putAndPromote = async function (key, value) {
+  const WLRUCandidate = this.WLRU.put(key, value);
   // if adding to the WLRU cache results in an eviction...
-  if (WLRUCandidate) {
+  if (WLRUCandidate.key) {
     // TODO: Double check that this pulls current size of cache correctly
     // if the probationary cache is at capacity...
     let winner = WLRUCandidate;
-    if (this.SLRU.probationaryLRU.nodeHash.size >= this.SLRU.probationaryLRU.capacity) {
+    if (this.SLRU.probationaryLRU.nodeHash.size >= Math.floor(this.SLRU.probationaryLRU.capacity)) {
       // send the last accessed item in the probationary cache to the TinyLFU
       const SLRUCandidate = this.SLRU.probationaryLRU.getCandidate();
       // determine which item will imrpove the hit-ratio most
-      const winner = this.TinyLFU(WLRUCandidate, SLRUCandidate);
+      winner = await this.TinyLFU(WLRUCandidate, SLRUCandidate);
     }
     // add the winner to the probationary SLRU 
-      this.SLRU.probationaryLRU.put(winner.key, winner);
+      this.SLRU.probationaryLRU.put(winner.key, winner.value);
   }
 }
 
@@ -63,6 +65,7 @@ WTinyLFUCache.prototype.populateAllHashes = function (
     // if the hash is not in the SLRU, check the WLRU
     if (!readVal) readVal = await this.WLRU.get(hash);
     if (readVal === "DELETED") return acc;
+    if (readVal) this.sketch.increment(JSON.stringify(readVal));
     if (!readVal) return undefined;
     const dataObj = {};
     for (const field in fields) {
@@ -148,6 +151,7 @@ WTinyLFUCache.prototype.write = async function (queryStr, respObj, deleteFlag) {
       if (resp) wasFoundIn = 'SLRU' 
       else resp = await this.WLRU.get(hash);
       if (resp && !wasFoundIn) wasFoundIn = 'WLRU';
+      if (resp) this.sketch.increment(JSON.stringify(resp));
       if (hash === "ROOT_QUERY" || hash === "ROOT_MUTATION") {
         if(deleteMutation === "") {
           this[hash] = Object.assign(this[hash], resFromNormalize[hash]);
@@ -174,6 +178,7 @@ WTinyLFUCache.prototype.write = async function (queryStr, respObj, deleteFlag) {
         else if (wasFoundIn === 'WLRU') await this.WLRU.put(hash, newObj);
       } else {
         const typeName = hash.slice(0, hash.indexOf('~'));
+        //TODO: check other caches first
         await this.putAndPromote(hash, resFromNormalize[hash]);
         for(const key in this.ROOT_QUERY) {
           if(key.includes(typeName + 's') || key.includes(plural(typeName))) {

--- a/test_files/rhum_test_files/wTinyLFU_test.js
+++ b/test_files/rhum_test_files/wTinyLFU_test.js
@@ -1,0 +1,12 @@
+import { assert, equal, assertStrictEquals, assertEquals } from "https://deno.land/std@0.181.0/testing/asserts.ts";
+import WTinyLFUCache from "../../src/Browser/wTinyLFUBrowserCache.js";
+import { FrequencySketch } from "../../src/Browser/FrequencySketch.js";
+
+// Cache creation
+Deno.test('creating a new cache creates subcaches with correct capacities', () => {
+  const cache = new WTinyLFUCache(1000)
+  assertEquals(cache.WLRU.capacity, 10);
+  assertEquals(cache.SLRU.protectedLRU.capacity, 792);
+  assertEquals(cache.SLRU.probationaryLRU.capacity, 198);
+  // console.log(cache);
+})


### PR DESCRIPTION
# Checklist

- [X] Bugfix
- [ ] New feature
- [ ] Refactor

# Related Issues

1) Items added to cache were sometimes added as entire nodes, leading to circular structures
2) Items promoted from probationary cache to protected cache persisted in the probationary cache as well
3) Frequency sketch was not functioning
4) Functioning frequency sketch was not successfully incrementing for items
5) items received by frequency sketch had unexpected shapes

# Solution

1) Fixed areas where entire node was being passed in to instead pass the node's value, returned object containing key and value from some w-TinyLFU methods instead of the entire node
2) Added a hash delete to the delete methods of SLRU sub-cache
3) Added frequency sketch initialization to the constructor of w-TinyLFU
4) Fixed frequency sketch to successfully create and populate its arrays
5) Adjusted the placement of the frequency sketch's increment function invocations to only happen on populateAllHashes and write.
