### PR TITLE
Add searchTerms options to w-tinyLFU

### DIFF
--- a/ObsidianWrapper/ObsidianWrapper.jsx
+++ b/ObsidianWrapper/ObsidianWrapper.jsx
@@ -7,7 +7,7 @@ import { insertTypenames } from '../src/Browser/insertTypenames.js';
 const cacheContext = React.createContext();
 
 function ObsidianWrapper(props) {
-  const { algo, capacity } = props
+  const { algo, capacity, searchTerms } = props
 
   const setAlgoCap = (algo, capacity) => {
     let cache;
@@ -141,7 +141,7 @@ function ObsidianWrapper(props) {
         if (cacheWrite && resObj.data[Object.keys(resObj.data)[0]] !== null) {
           if (!wholeQuery) cache.writeWholeQuery(query, deepResObj);
           else if(resObj.data[Object.keys(resObj.data)[0]].length > cache.capacity) console.log('Please increase cache capacity');
-          else cache.write(query, deepResObj);
+          else cache.write(query, deepResObj, searchTerms);
         }
         const cacheMissResponseTime = Date.now() - startTime;
         /*chrome.runtime.sendMessage(chromeExtensionId, {
@@ -237,7 +237,7 @@ function ObsidianWrapper(props) {
         if (!cacheWrite) return responseObj;
         // first behaviour when delete cache is set to true
         if (toDelete) {
-          cache.write(mutation, responseObj, true);
+          cache.write(mutation, responseObj, searchTerms, true);
           return responseObj;
         }
         // second behaviour if update function provided
@@ -245,7 +245,7 @@ function ObsidianWrapper(props) {
           update(cache, responseObj);
         }
 
-        if(!responseObj.errors) cache.write(mutation, responseObj);
+        if(!responseObj.errors) cache.write(mutation, responseObj, searchTerms);
         // third behaviour just for normal update (no-delete, no update function)
         console.log('WriteThrough - true ', responseObj);
         return responseObj;

--- a/src/Browser/lfuBrowserCache.js
+++ b/src/Browser/lfuBrowserCache.js
@@ -152,7 +152,7 @@ LFUCache.prototype.read = async function (queryStr) {
   return { data: responseObject };
 };
 
-LFUCache.prototype.write = async function (queryStr, respObj, deleteFlag) {
+LFUCache.prototype.write = async function (queryStr, respObj, searchTerms, deleteFlag) {
   let nullFlag = false;
   let deleteMutation = "";
   for(const query in respObj.data) {
@@ -194,6 +194,16 @@ LFUCache.prototype.write = async function (queryStr, respObj, deleteFlag) {
           if(key.includes(typeName + 's') || key.includes(plural(typeName))) {
             this.ROOT_QUERY[key].push(hash);
           }
+        }
+        if (searchTerms && queryStr.slice(8, 11) === 'all'){
+          searchTerms.forEach(el => {
+            console.log('element is: ', el);
+            const elVal = resFromNormalize[hash][el].replaceAll(' ', '');
+            const hashKey = `one${typeName}(${el}:"${elVal}")`;
+            console.log('hashKey is', hashKey);
+            if (!this.ROOT_QUERY[hashKey]) this.ROOT_QUERY[hashKey] = [];
+            this.ROOT_QUERY[hashKey].push(hash);
+          });
         }
       }
     }

--- a/src/Browser/lruBrowserCache.js
+++ b/src/Browser/lruBrowserCache.js
@@ -140,7 +140,7 @@ LRUCache.prototype.read = async function (queryStr) {
   return { data: responseObject };
 };
 
-LRUCache.prototype.write = async function (queryStr, respObj, deleteFlag) {
+LRUCache.prototype.write = async function (queryStr, respObj, searchTerms, deleteFlag) {
   let nullFlag = false;
   let deleteMutation = "";
   for(const query in respObj.data) {
@@ -182,6 +182,16 @@ LRUCache.prototype.write = async function (queryStr, respObj, deleteFlag) {
           if(key.includes(typeName + 's') || key.includes(plural(typeName))) {
             this.ROOT_QUERY[key].push(hash);
           }
+        }
+        if (searchTerms && queryStr.slice(8, 11) === 'all'){
+          searchTerms.forEach(el => {
+            console.log('element is: ', el);
+            const elVal = resFromNormalize[hash][el].replaceAll(' ', '');
+            const hashKey = `one${typeName}(${el}:"${elVal}")`;
+            console.log('hashKey is', hashKey);
+            if (!this.ROOT_QUERY[hashKey]) this.ROOT_QUERY[hashKey] = [];
+            this.ROOT_QUERY[hashKey].push(hash);
+          });
         }
       }
     }

--- a/src/Browser/wTinyLFUBrowserCache.js
+++ b/src/Browser/wTinyLFUBrowserCache.js
@@ -132,7 +132,7 @@ WTinyLFUCache.prototype.read = async function (queryStr) {
   return { data: responseObject };
 };
 
-WTinyLFUCache.prototype.write = async function (queryStr, respObj, deleteFlag) {
+WTinyLFUCache.prototype.write = async function (queryStr, respObj, searchTerms, deleteFlag) {
   let nullFlag = false;
   let deleteMutation = "";
   let wasFoundIn = null;
@@ -184,6 +184,16 @@ WTinyLFUCache.prototype.write = async function (queryStr, respObj, deleteFlag) {
           if(key.includes(typeName + 's') || key.includes(plural(typeName))) {
             this.ROOT_QUERY[key].push(hash);
           }
+        }
+        if (searchTerms && queryStr.slice(8, 11) === 'all'){
+          searchTerms.forEach(el => {
+            console.log('element is: ', el);
+            const elVal = resFromNormalize[hash][el].replaceAll(' ', '');
+            const hashKey = `one${typeName}(${el}:"${elVal}")`;
+            console.log('hashKey is', hashKey);
+            if (!this.ROOT_QUERY[hashKey]) this.ROOT_QUERY[hashKey] = [];
+            this.ROOT_QUERY[hashKey].push(hash);
+          });
         }
       }
     }


### PR DESCRIPTION
# Checklist

- [ ] Bugfix
- [X] New feature
- [ ] Refactor

# Related Issue

After doing a search fo all of something, an individual search is not pulled from the cache. Obsidian is designed for any application and doesn’t know the specific search terms used in any one application or database using its wrapper. This means that when making an "all_____" query only the "all" version is stored in ROOT_QUERY and other searches for individual data entities that fall under that query don’t know what key to use to find their data in the cache. "all___" searches do not contain search arguments, as they are blanket searches. This was not a bug, as initially assumed, but a deliberate design choice. 

# Solution

We now provide developers the option to specify their application’s search terms in the wrapper as an array of strings. When writing to the cache/ROOT_QUERY for an "all" query and search terms have been provided by the developer, we iterate through the normalized results of the query and use those to write a key/value pair to the ROOT_QUERY object for each of the terms in the search terms array. The key contains the kind of search that would be made for that one item according to developer specifications; the value is the hash key to look up the data from the cache. Now wTinyLFU can do an all search, followed by individual searches and immediately find those individual entities in the cache.

# Additional Info

We are in the process of adding this feature to the LRU and LFU browser cache options.
