### PR TITLE
added functionality for persistent queries, refactored ObsidianRouter

### DIFF
--- a/src/Obsidian.ts
+++ b/src/Obsidian.ts
@@ -2,7 +2,6 @@ import { graphql } from 'https://cdn.pika.dev/graphql@15.0.0';
 import { renderPlaygroundPage } from 'https://deno.land/x/oak_graphql@0.6.2/graphql-playground-html/render-playground-html.ts';
 import { makeExecutableSchema } from 'https://deno.land/x/oak_graphql@0.6.2/graphql-tools/schema/makeExecutableSchema.ts';
 import { Cache } from './quickCache.js';
-import LFUCache from './Browser/lfuBrowserCache.js';
 import queryDepthLimiter from './DoSSecurity.ts';
 import { restructure } from './restructure.ts';
 import { rebuildFromQuery } from './rebuild.js';
@@ -10,6 +9,7 @@ import { normalizeObject } from './normalize.ts';
 import { transformResponse, detransformResponse } from './transformResponse.ts';
 import { isMutation, invalidateCache } from './invalidateCacheCheck.ts';
 import { mapSelectionSet } from './mapSelections.js';
+import { HashTable } from './queryHash.js';
 
 interface Constructable<T> {
   new (...args: any): T & OakRouter;
@@ -28,13 +28,14 @@ export interface ObsidianRouterOptions<T> {
   resolvers: ResolversProps;
   context?: (ctx: any) => any;
   usePlayground?: boolean;
-  useCache?: boolean; // trivial parameter
+  useCache?: boolean;
   redisPort?: number;
+  redisURI?: string;
   policy?: string;
   maxmemory?: string;
+  persistQueries?: boolean;
+  hashTableSize?: number;
   maxQueryDepth?: number;
-  useQueryCache?: boolean; // trivial parameter
-  useRebuildCache?: boolean;
   customIdentifier?: Array<string>;
   mutationTableMap?: Record<string, unknown>; // Deno recommended type name
 }
@@ -60,53 +61,153 @@ export async function ObsidianRouter<T>({
   resolvers,
   context,
   usePlayground = false,
-  useCache = true,
+  useCache = true, // default to true
   redisPort = 6379,
+  redisURI = '',
   policy = 'allkeys-lru',
   maxmemory = '2000mb',
+  persistQueries = false, // default to false
+  hashTableSize = 16, // default to 16
   maxQueryDepth = 0,
-  useQueryCache = true,
-  useRebuildCache = true,
-  customIdentifier = ['id', '__typename'],
+  customIdentifier = ['_id', '__typename'],
   mutationTableMap = {}, // Developer passes in object where keys are add mutations and values are arrays of affected tables
 }: ObsidianRouterOptions<T>): Promise<T> {
-  redisPortExport = redisPort;
+  console.log('HELLOOOOOOOO ;)');
   const router = new Router();
   const schema = makeExecutableSchema({ typeDefs, resolvers });
-  // const cache = new LFUCache(50); // If using LFU Browser Caching, uncomment line
-  const cache = new Cache(); // If using Redis caching, uncomment line
-  cache.cacheClear();
-  if (policy || maxmemory) {
-    // set redis configurations
-    cache.configSet('maxmemory-policy', policy);
-    cache.configSet('maxmemory', maxmemory);
+
+  let cache, hashTable;
+  if (useCache) {
+    cache = new Cache();
+    // potentially insert logic to connect to cach
+    cache.cacheClear();
+    console.log('cleared the Cache');
+    if (policy || maxmemory) {
+      // set redis configurations
+      cache.configSet('maxmemory-policy', policy);
+      cache.configSet('maxmemory', maxmemory);
+    }
+  }
+  if (persistQueries) {
+    hashTable = new HashTable(hashTableSize);
   }
 
   //post
   await router.post(path, async (ctx: any) => {
-    
+    console.log('KEJHKJHEFKJSDHF');
     const t0 = performance.now(); // Used for demonstration of cache vs. db performance times
 
     const { response, request } = ctx;
     if (!request.hasBody) return;
+
     try {
-      const contextResult = context ? await context(ctx) : undefined;
+      console.log('hellooooo from try');
+      let queryStr;
       let body = await request.body().value;
+      if (persistQueries && body.hash && !body.query) {
+        console.log('persistQueries && body.hash && !body.query');
+        const { hash } = body;
+        console.log('hash is ', hash);
+        console.log('hashTable.table is ', hashTable.table);
+        queryStr = hashTable.get(hash);
+        console.log('queryStr is ',queryStr);
+        // this may set query str to undefined need to figure it out
+      } else if (persistQueries && body.hash && body.query) {
+        console.log('persistQueries && body.hash && body.query');
+        const { hash, query } = body;
+        hashTable.add(hash, query);
+        console.log('hashTable.table is ', hashTable.table);
+        queryStr = query;
+      } else if (persistQueries && !body.hash) {
+        console.log('persistQueries && !body.hash');
+        throw new Error('Hashed query not found');
+      } else if (!persistQueries) {
+        console.log('!persistQueries');
+        queryStr = body.query;
+      } else {
+        console.log('else');
+        throw new Error('Error occured while setting queryStr');
+      }
 
-      const selectedFields = mapSelectionSet(body.query); // Gets requested fields from query and saves into an array
-
-      if (maxQueryDepth) queryDepthLimiter(body.query, maxQueryDepth); // If a securty limit is set for maxQueryDepth, invoke queryDepthLimiter, which throws error if query depth exceeds maximum
+      console.log('context is ', context);
+      const contextResult = context ? await context(ctx) : undefined;
+      console.log('contextResult is ', contextResult);
+      // let body = await request.body().value;
+      console.log('here?');
+      const selectedFields = mapSelectionSet(queryStr); // Gets requested fields from query and saves into an array
+      console.log('there?');
+      if (maxQueryDepth) queryDepthLimiter(queryStr, maxQueryDepth); // If a securty limit is set for maxQueryDepth, invoke queryDepthLimiter, which throws error if query depth exceeds maximum
+      console.log('anywhere?');
       let restructuredBody = { query: restructure(body) }; // Restructure gets rid of variables and fragments from the query
-
-      let cacheQueryValue = await cache.read(body.query); // Parses query string into query key and checks cache for that key
-
+      console.log('up?');
+      console.log('down?');
       // Is query in cache?
-      if (useCache && useQueryCache && cacheQueryValue) {
+      if (useCache) {
+        console.log('we are using a cache');
+        let cacheQueryValue = await cache.read(queryStr); // Parses query string into query key and checks cache for that key
+        console.log('cacheQueryValue is ', cacheQueryValue);
+        // if we missed the cache.
+        if (!cacheQueryValue) {
+          console.log('missed the redis cacheeee');
+          const gqlResponse = await (graphql as any)(
+            schema,
+            body.query,
+            resolvers,
+            contextResult,
+            body.variables || undefined,
+            body.operationName || undefined
+          );
+
+          console.log('gqlResponse is ', gqlResponse);
+
+          // customIdentifier is a default param for Obsidian Router - defaults to ['id', '__typename']
+          // this is the hashableKeys arg for normalizeObject
+          const normalizedGQLResponse = normalizeObject( // Recursively flattens an arbitrarily nested object into an objects with hash key and hashable object pairs
+            gqlResponse,
+            customIdentifier
+          );
+          console.log('normalizedGQLResponse is ', normalizedGQLResponse);
+
+          if (isMutation(restructuredBody)) { // If operation is mutation, invalidate relevant responses in cache
+            console.log('restructuredBody is a mutation');
+            const queryString = body; 
+            invalidateCache(
+              normalizedGQLResponse,
+              queryString.query,
+              mutationTableMap
+            );
+          }
+          // If read query: run query, normalize GQL response, transform GQL response, write to cache, and write pieces of normalized GQL response objects
+          else {
+            const transformedGQLResponse = transformResponse(
+              gqlResponse,
+              customIdentifier
+            );
+
+            console.log('transformedGQLResponse is ', transformedGQLResponse);
+
+            await cache.write(body.query, transformedGQLResponse, false);
+            for (const key in normalizedGQLResponse) {
+              await cache.cacheWriteObject(key, normalizedGQLResponse[key]);
+            }
+          }
+          response.status = 200;
+          response.body = gqlResponse; // Returns response from database
+          const t1 = performance.now();
+          console.log(
+            '%c Obsidian received new data and took ' +
+              (t1 - t0) +
+              ' milliseconds',
+            'background: #222; color: #FFFF00'
+          );
+        }
+        console.log('left');
         let detransformedCacheQueryValue = await detransformResponse( // Returns a nested object representing the original graphQL response object for a given queryKey 
           restructuredBody.query,
           cacheQueryValue,
           selectedFields
         );
+        console.log('detransformedCacheQueryValue is ', detransformedCacheQueryValue);
         if (!detransformedCacheQueryValue) {
           // cache was evicted if any partial cache is missing, which causes detransformResponse to return undefined
           cacheQueryValue = undefined;
@@ -122,8 +223,10 @@ export async function ObsidianRouter<T>({
             'background: #222; color: #00FF00'
           );
         }
-      } // If not in cache:
-      if (useCache && useQueryCache && !cacheQueryValue) {
+
+      } else {
+        console.log('we are not using a cache :(');
+        // if not using a cache, go directly to the database
         const gqlResponse = await (graphql as any)(
           schema,
           body.query,
@@ -133,30 +236,7 @@ export async function ObsidianRouter<T>({
           body.operationName || undefined
         );
 
-        const normalizedGQLResponse = normalizeObject( // Recursively flattens an arbitrarily nested object into an objects with hash key and hashable object pairs
-          gqlResponse,
-          customIdentifier
-        );
-
-        if (isMutation(restructuredBody)) { // If operation is mutation, invalidate relevant responses in cache
-          const queryString = body; 
-          invalidateCache(
-            normalizedGQLResponse,
-            queryString.query,
-            mutationTableMap
-          );
-        }
-        // If read query: run query, normalize GQL response, transform GQL response, write to cache, and write pieces of normalized GQL response objects
-        else {
-          const transformedGQLResponse = transformResponse(
-            gqlResponse,
-            customIdentifier
-          );
-          await cache.write(body.query, transformedGQLResponse, false);
-          for (const key in normalizedGQLResponse) {
-            await cache.cacheWriteObject(key, normalizedGQLResponse[key]);
-          }
-        }
+        console.log('gqlResponse is ', gqlResponse);
         response.status = 200;
         response.body = gqlResponse; // Returns response from database
         const t1 = performance.now();

--- a/src/queryHash.js
+++ b/src/queryHash.js
@@ -1,0 +1,83 @@
+// Create hash table
+class Node {
+  constructor(key, str) {
+    this.value = {key, str};
+    this.next = null;
+  }
+}
+
+class LinkedList {
+  constructor(node) {
+    this.head = null;
+    this.tail = null;
+  }
+
+  // adds a node to the end of the linked list
+  addNode(key, str) {
+    if (this.head === null) {
+      this.head = new Node(key, str);
+      this.tail = this.head;
+    } else {
+      this.tail.next = new Node(key, str);
+      this.tail = this.tail.next
+    }
+  }
+
+  // finds a node from the SHA256-hashed queryStr and returns the queryStr
+  getNode(key) {
+    if (this.head === null) return undefined;
+    let currNode = this.head;
+    while (currNode) {
+      if (currNode.value.key === key) return currNode.value.str;
+      else currNode = currNode.next;
+    }
+    return undefined;
+  }
+}
+
+export class HashTable {
+  constructor(size) {
+    this.SIZE = size;
+    this.table = new Array(this.SIZE);
+  }
+
+  // adds a value to the hashTable
+  add(sha256Str, str) {
+    const index = hashSlingingSlasher(sha256Str, this.SIZE);
+    // if there is nothing at that index of the hash table
+    if (!this.table[index]) {
+      // initialize a new linked list and add a node to it
+      this.table[index] = new LinkedList();
+      this.table[index].addNode(sha256Str, str);
+    // if there is already a linked list at that index
+    } else {
+      // add a new node
+      this.table[index].addNode(sha256Str, str);
+    }
+  }
+
+  // gets the queryStr given the SHA256-Hashed queryStr
+  get(key) {
+
+    const index = hashSlingingSlasher(key, this.SIZE);
+    if (!this.table[index]) return undefined;
+    return this.table[index].getNode(key);
+  }
+
+  // a function that removes all removes all items from hash table
+  // unsure if we will need this so I have not made it yet
+  // clearAll (){
+  // }
+}
+
+// hashing function
+function hashSlingingSlasher(string, size) {
+  let hash = 0;
+  if (string.length === 0) return hash;
+  for (let i = 0; i < string.length; i++) {
+    const letter = string.charCodeAt(i);
+    hash = ((hash << 5) - hash) + letter;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  return Math.abs(hash) % size;
+}


### PR DESCRIPTION
# Checklist

- [] Bugfix
- [x] New feature
- [x] Refactor

# Related Issue

- Needed to corporate persistent Queries as a new feature, however the logical order of Obsidian.ts > ObsidianRouter was incompatible with incorporating new features of persistent queries. In order to incorporate persistent queries, obsidian router options needed to be modified, but obsidian router options seemed to not have been managed for a couple of iterations. Functionality to opt out of server side caching was broken. However, Obsidian router's logic mandated that a server side cache must be utilized, had unnecessary arguments, was reading from redis cache before use of the cache was confirmed, could not perform graphQL query while opting out of server side caching, normalization was non-functional etc.

# Solution

- Near total refactor of Obsidian.ts to be logically more sound and appropriate. Incorporate persistent queries on server side.

# Additional Info

- Obsidian.ts > Obsidian Router is still not fully functional due to a broken transformResponse and detransformResponse. Will work when not using a cache but will not work when using a cache. The transformResponse and detransformResponse functions are responsible for reading from and writing to the redis cache, which is why redis caching is still not functional. 
- Persistent queries still need to be incorporated on client side.
